### PR TITLE
Auth MVP: Drizzle schemas + cookie sessions + server actions (Better Auth-ready)

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'drizzle-kit';
 
 export default defineConfig({
-  schema: './src/lib/db/schema.ts',
+  schema: './src/lib/db/schema/index.ts',
   out: './drizzle',
   dialect: 'postgresql',
   dbCredentials: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@neondatabase/serverless": "^1.0.1",
         "@radix-ui/react-slot": "^1.2.3",
+        "bcryptjs": "^3.0.2",
         "better-auth": "^1.3.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -22,6 +23,7 @@
         "react-hook-form": "^7.62.0",
         "react-icons": "^5.5.0",
         "tailwind-merge": "^3.3.1",
+        "zod": "^4.1.8",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
@@ -3315,6 +3317,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/better-auth": {
       "version": "1.3.9",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@neondatabase/serverless": "^1.0.1",
     "@radix-ui/react-slot": "^1.2.3",
+    "bcryptjs": "^3.0.2",
     "better-auth": "^1.3.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -28,6 +29,7 @@
     "react-hook-form": "^7.62.0",
     "react-icons": "^5.5.0",
     "tailwind-merge": "^3.3.1",
+    "zod": "^4.1.8",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,5 +1,5 @@
 import { db } from '../src/lib/db';
-import { glossaryTerms } from '../src/lib/db/schema';
+import { glossaryTerms } from '../src/lib/db/schema/glossary-schema';
 
 const sampleTerms = [
   {

--- a/src/lib/auth/actions.ts
+++ b/src/lib/auth/actions.ts
@@ -1,0 +1,86 @@
+'use server';
+
+import { z } from 'zod';
+import { hash, compare } from 'bcryptjs';
+import { db } from '@/lib/db';
+import { account, user } from '@/lib/db/schema';
+import { createSession, destroySession, getCurrentSession } from './index';
+import { and, eq } from 'drizzle-orm';
+
+const signUpSchema = z.object({
+  name: z.string().trim().min(1).optional(),
+  email: z.string().email(),
+  password: z.string().min(8),
+});
+
+const signInSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+});
+
+export async function signUp(input: z.infer<typeof signUpSchema>) {
+  const data = signUpSchema.parse(input);
+
+  const existing = await db.query.user.findFirst({
+    where: (u, { eq }) => eq(u.email, data.email),
+  });
+  if (existing) {
+    throw new Error('Email is already in use');
+  }
+
+  const passwordHash = await hash(data.password, 12);
+
+  const [createdUser] = await db
+    .insert(user)
+    .values({
+      email: data.email,
+      name: data.name,
+    })
+    .returning();
+
+  await db.insert(account).values({
+    userId: createdUser.id,
+    accountId: data.email,
+    password: passwordHash,
+  });
+
+  await createSession(createdUser.id, 1000 * 60 * 60 * 24 * 30);
+
+  return { ok: true, userId: createdUser.id };
+}
+
+export async function signIn(input: z.infer<typeof signInSchema>) {
+  const data = signInSchema.parse(input);
+
+  const [u] = await db.select().from(user).where(eq(user.email, data.email)).limit(1);
+  if (!u) {
+    throw new Error('Invalid email or password');
+  }
+
+  const [acc] = await db
+    .select()
+    .from(account)
+    .where(and(eq(account.userId, u.id), eq(account.accountId, data.email)))
+    .limit(1);
+
+  if (!acc || !acc.password) {
+    throw new Error('Invalid email or password');
+  }
+
+  const valid = await compare(data.password, acc.password);
+  if (!valid) {
+    throw new Error('Invalid email or password');
+  }
+
+  await createSession(u.id, 1000 * 60 * 60 * 24 * 30);
+
+  return { ok: true, userId: u.id };
+}
+
+export async function signOut() {
+  const sess = await getCurrentSession();
+  if (!sess) return { ok: true };
+
+  await destroySession(sess.token);
+  return { ok: true };
+}

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -1,0 +1,87 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { db } from '@/lib/db';
+import { account, session, user } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { randomUUID } from 'crypto';
+
+const AUTH_COOKIE_NAME = 'auth_session';
+
+export async function getCurrentSession() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(AUTH_COOKIE_NAME)?.value;
+  if (!token) return null;
+
+  const [sess] = await db
+    .select()
+    .from(session)
+    .where(eq(session.token, token))
+    .limit(1);
+
+  if (!sess) return null;
+  if (sess.expiresAt && sess.expiresAt < new Date()) {
+    await db.delete(session).where(eq(session.id, sess.id));
+    cookieStore.delete(AUTH_COOKIE_NAME);
+    return null;
+  }
+  return sess;
+}
+
+export async function getCurrentUser() {
+  const sess = await getCurrentSession();
+  if (!sess) return null;
+
+  const [u] = await db.select().from(user).where(eq(user.id, sess.userId)).limit(1);
+  if (!u) return null;
+
+  return { id: u.id, email: u.email, name: u.name ?? null };
+}
+
+export async function createSession(userId: string, ttlMs: number, userAgent?: string | null, ipAddress?: string | null) {
+  const token = randomUUID();
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + ttlMs);
+
+  await db.insert(session).values({
+    userId,
+    token,
+    userAgent: userAgent ?? undefined,
+    ipAddress: ipAddress ?? undefined,
+    expiresAt,
+  });
+
+  const cookieStore = await cookies();
+  cookieStore.set(AUTH_COOKIE_NAME, token, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: true,
+    path: '/',
+    expires: expiresAt,
+  });
+
+  return token;
+}
+
+export async function destroySession(token: string) {
+  const cookieStore = await cookies();
+  await db.delete(session).where(eq(session.token, token));
+  cookieStore.delete(AUTH_COOKIE_NAME);
+}
+
+export async function getAccountByEmail(email: string) {
+  const [u] = await db.select().from(user).where(eq(user.email, email)).limit(1);
+  if (!u) return null;
+
+  const [acc] = await db
+    .select()
+    .from(account)
+    .where(and(eq(account.userId, u.id), eq(account.accountId, email)))
+    .limit(1);
+
+  if (!acc) return null;
+
+  return { user: u, account: acc };
+}
+
+export { AUTH_COOKIE_NAME };

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -1,0 +1,5 @@
+export type SessionUser = {
+  id: string;
+  email: string;
+  name?: string | null;
+};

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,1 +1,2 @@
-export * from './schema';
+export * from './schema/glossary-schema';
+export * from './schema/auth-schema';

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,13 +1,1 @@
-import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
-
-export const glossaryTerms = pgTable('glossary_terms', {
-  id: uuid('id').defaultRandom().primaryKey(),
-  term: text('term').notNull(),
-  definition: text('definition').notNull(),
-  category: text('category').notNull(),
-  createdAt: timestamp('created_at').defaultNow().notNull(),
-  updatedAt: timestamp('updated_at').defaultNow().notNull(),
-});
-
-export type GlossaryTerm = typeof glossaryTerms.$inferSelect;
-export type NewGlossaryTerm = typeof glossaryTerms.$inferInsert;
+export * from './schema';

--- a/src/lib/db/schema/auth-schema.ts
+++ b/src/lib/db/schema/auth-schema.ts
@@ -1,0 +1,68 @@
+import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+
+export const user = pgTable('user', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  name: text('name'),
+  email: text('email').notNull().unique(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export const account = pgTable('account', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  userId: uuid('user_id')
+    .notNull()
+    .references(() => user.id, { onDelete: 'cascade' }),
+  accountId: text('account_id').notNull(),
+  accessToken: text('access_token'),
+  refreshToken: text('refresh_token'),
+  accessTokenExpiresAt: timestamp('access_token_expires_at'),
+  refreshTokenExpiresAt: timestamp('refresh_token_expires_at'),
+  scope: text('scope'),
+  idToken: text('id_token'),
+  password: text('password'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export const session = pgTable('session', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  userId: uuid('user_id')
+    .notNull()
+    .references(() => user.id, { onDelete: 'cascade' }),
+  token: text('token').notNull().unique(),
+  ipAddress: text('ip_address'),
+  userAgent: text('user_agent'),
+  expiresAt: timestamp('expires_at').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export const userRelations = relations(user, ({ many }) => ({
+  accounts: many(account),
+  sessions: many(session),
+}));
+
+export const accountRelations = relations(account, ({ one }) => ({
+  user: one(user, {
+    fields: [account.userId],
+    references: [user.id],
+  }),
+}));
+
+export const sessionRelations = relations(session, ({ one }) => ({
+  user: one(user, {
+    fields: [session.userId],
+    references: [user.id],
+  }),
+}));
+
+export type User = typeof user.$inferSelect;
+export type NewUser = typeof user.$inferInsert;
+
+export type Account = typeof account.$inferSelect;
+export type NewAccount = typeof account.$inferInsert;
+
+export type Session = typeof session.$inferSelect;
+export type NewSession = typeof session.$inferInsert;

--- a/src/lib/db/schema/glossary-schema.ts
+++ b/src/lib/db/schema/glossary-schema.ts
@@ -1,0 +1,13 @@
+import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+
+export const glossaryTerms = pgTable('glossary_terms', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  term: text('term').notNull(),
+  definition: text('definition').notNull(),
+  category: text('category').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export type GlossaryTerm = typeof glossaryTerms.$inferSelect;
+export type NewGlossaryTerm = typeof glossaryTerms.$inferInsert;

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -1,0 +1,2 @@
+export * from './auth-schema';
+export * from './glossary-schema';


### PR DESCRIPTION
# Auth MVP: Drizzle schemas + cookie sessions + server actions (Better Auth-ready)

## Summary

This PR implements the foundational authentication system for the glossary application with modular Drizzle schemas and cookie-based session management. Key changes include:

- **Modular Database Schema**: Refactored single schema file into separate modules (`auth-schema.ts`, `glossary-schema.ts`) with proper barrel exports
- **Authentication Tables**: Added `user`, `account`, and `session` tables with proper relationships and constraints following Better Auth patterns
- **Server Actions**: Implemented `signUp`, `signIn`, and `signOut` server actions with Zod validation (8+ character passwords)
- **Session Management**: Custom cookie-based sessions using `auth_session` HTTP-only cookies with 30-day TTL
- **Dependencies**: Added `zod` for validation and `bcryptjs` for password hashing

## Review & Testing Checklist for Human

**4 Critical Items to Verify:**

- [ ] **Run database migration**: Execute `npm run db:generate && npm run db:migrate` to create the new auth tables and verify the schema looks correct
- [ ] **Test complete auth flow**: Create a test user via `signUp`, verify `signIn` works, check `signOut` clears session, and confirm `getCurrentUser()` returns expected data
- [ ] **Security review**: Examine cookie settings, password hashing (bcrypt rounds=12), session token generation, and verify no secrets are logged or exposed
- [ ] **Verify existing functionality**: Run `npm run db:seed` and test that glossary terms display correctly after the schema refactoring

### Notes

⚠️ **Important**: This implementation uses a custom auth system that follows Better Auth patterns but doesn't actually integrate the Better Auth library. If you specifically need Better Auth integration, we should discuss whether to refactor this approach.

The auth system is backend-ready but has no UI integration yet - you'll need to build sign-in/sign-up forms to consume these server actions.

**Link to Devin run**: https://app.devin.ai/sessions/fef507725a104bd28fab0f9771b0ddc6  
**Requested by**: @archerzou