### PR TITLE
Fix sign-up 500: validation alignment and graceful error handling

### DIFF
--- a/src/lib/auth/actions.ts
+++ b/src/lib/auth/actions.ts
@@ -4,7 +4,7 @@ import { headers } from "next/headers";
 import { z } from "zod";
 import { auth } from "@/lib/auth";
 
-const emailSchema = z.email();
+const emailSchema = z.string().email();
 const passwordSchema = z.string().min(8).max(128);
 const nameSchema = z.string().min(1).max(100);
 
@@ -15,23 +15,28 @@ const signUpSchema = z.object({
 });
 
 export async function signUp(formData: FormData) {
-  const rawData = {
-    name: formData.get("name") as string,
-    email: formData.get("email") as string,
-    password: formData.get("password") as string,
-  };
+  try {
+    const rawData = {
+      name: formData.get("name") as string,
+      email: formData.get("email") as string,
+      password: formData.get("password") as string,
+    };
 
-  const data = signUpSchema.parse(rawData);
+    const data = signUpSchema.parse(rawData);
 
-  const res = await auth.api.signUpEmail({
-    body: {
-      email: data.email,
-      password: data.password,
-      name: data.name,
-    },
-  });
+    const res = await auth.api.signUpEmail({
+      body: {
+        email: data.email,
+        password: data.password,
+        name: data.name,
+      },
+    });
 
-  return { ok: true, userId: res.user?.id };
+    return { ok: true, userId: res.user?.id };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to create user";
+    return { ok: false, error: message as string };
+  }
 }
 
 const signInSchema = z.object({


### PR DESCRIPTION
# Fix sign-up 500: validation alignment and graceful error handling

## Summary

Fixes the 500 Internal Server Error when users click Register on the sign-up form. The issue was caused by:

1. **Invalid Zod schema**: Used `z.email()` instead of `z.string().email()` in server validation
2. **Validation mismatch**: Client allowed 6-char passwords while server required 8+ chars
3. **Missing error handling**: Server action threw unhandled exceptions that became 500s
4. **No error display**: Client had no way to show server-side validation errors to users

**Changes made:**
- Fixed email schema validation in server action
- Added try/catch to return structured errors instead of throwing
- Aligned password minimum length to 8 characters on both client and server
- Made name field required for sign-up (was optional)
- Added server error display in the form UI

## Review & Testing Checklist for Human

- [ ] **Test sign-up happy path**: Create a new user account and verify it redirects to "/" without 500 errors
- [ ] **Test duplicate email error**: Try signing up with an existing email and verify a readable error appears (not a 500)
- [ ] **Test client validation**: Try submitting with password < 8 chars or empty name - form should block submission with validation messages
- [ ] **Test sign-in flow**: Verify existing sign-in functionality still works (wasn't directly modified but want to ensure no regressions)

### Notes

The changes assume Better Auth returns standard error objects, but I didn't test locally so the error handling may need refinement based on actual Better Auth responses.

**Link to Devin run**: https://app.devin.ai/sessions/c434299e1e0d45fcb04c8732d98f89df  
**Requested by**: Archer Zou (@archerzou)