### PR TITLE
feat(glossary): Server Actions CRUD for Terms & Categories + page wiring + params fix

### DIFF
--- a/src/app/(root)/create-term/page.tsx
+++ b/src/app/(root)/create-term/page.tsx
@@ -1,22 +1,20 @@
-"use client";
-
 import { TermForm } from "@/components/Term-Form";
-import { upsertTerm } from "@/lib/mock/terms";
-import { useRouter } from "next/navigation";
+import { createTerm } from "@/lib/actions/terms";
+import { redirect } from "next/navigation";
 
 export default function Page() {
-  const router = useRouter();
+  async function onSubmit(values: { term: string; definition: string; categoryId: string }) {
+    "use server";
+    const { id } = await createTerm(values);
+    redirect(`/terms/${id}`);
+  }
 
   return (
-      <TermForm
-          mode="create"
-          onSubmit={(values) => {
-            const id = crypto.randomUUID();
-            upsertTerm({ id, ...values });
-            router.push(`/terms/${id}`);
-          }}
-          title="Create a Term"
-          submitLabel="Submit"
-      />
+    <TermForm
+      mode="create"
+      onSubmit={onSubmit}
+      title="Create a Term"
+      submitLabel="Submit"
+    />
   );
 }

--- a/src/app/(root)/page.tsx
+++ b/src/app/(root)/page.tsx
@@ -1,93 +1,18 @@
 import { GlossaryList } from "@/components/glossary-list";
 import { AlphabetNav } from "@/components/glossary/AlphabetNav";
 import { SearchBar } from "@/components/glossary/SearchBar";
-import { Term } from "@/lib/db/schema";
-import {getCurrentUser} from "@/lib/auth/actions";
+import { getTerms } from "@/lib/actions/terms";
+export const dynamic = 'force-dynamic';
 
-const TERMS: Term[] = [
-    {
-        id: "1",
-        term: "Alt Text",
-        categoryId: "1",
-        definition:
-            "Text description of an image used by search engines and screen readers to understand image content.",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-    },
-    {
-        id: "2",
-        term: "Backlink",
-        categoryId: "3",
-        definition:
-            "A link from another site to your site. High-quality backlinks can improve search rankings.",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-    },
-    {
-        id: "3",
-        term: "Content Pillar",
-        categoryId: "2",
-        definition:
-            "A comprehensive resource that anchors related cluster content targeting specific audience needs.",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-    },
-    {
-        id: "4",
-        term: "Domain Authority",
-        categoryId: "1",
-        definition:
-            "A predictive metric estimating how likely a website is to rank on search engine result pages.",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-    },
-    {
-        id: "5",
-        term: "Embeddings",
-        categoryId: "1",
-        definition:
-            "Numeric vector representations of text used by AI models to compute similarity and retrieve context.",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-    },
-    {
-        id: "6",
-        term: "Funnel",
-        categoryId: "3",
-        definition:
-            "The journey a user takes from awareness to conversion, often mapped to content across stages.",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-    },
-    {
-        id: "7",
-        term: "Generative AI",
-        categoryId: "2",
-        definition:
-            "AI systems that create new content such as text, images, or audio from learned patterns.",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-    },
-    {
-        id: "8",
-        term: "Machine Learning Operations (MLOps)",
-        categoryId: "1",
-        definition:
-            "An end-to-end discipline that combines practices, tools, and cultural philosophies to reliably develop, deploy, monitor, and continuously improve machine learning systems in production. MLOps spans dataset versioning, feature stores, model training and evaluation pipelines, experiment tracking, continuous integration/continuous delivery (CI/CD) for models, scalable online/offline inference, observability (data and model drift detection), governance and compliance, rollback strategies, and cross-functional collaboration between data scientists, ML engineers, DevOps, security, and product teams. Effective MLOps minimizes time-to-value, reduces operational risk, and ensures models remain accurate, safe, and aligned with business outcomes over their lifecycle, even as data and user behavior evolve.",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-    },
-];
 
 export default async function Home() {
-    const user = await getCurrentUser();
+  const terms = await getTerms();
 
-    console.log('user', user);
   return (
     <div className="space-y-6">
       <SearchBar />
       <AlphabetNav />
-      <GlossaryList initialTerms={TERMS} />
+      <GlossaryList initialTerms={terms} />
     </div>
   );
 }

--- a/src/app/(root)/terms/[id]/page.tsx
+++ b/src/app/(root)/terms/[id]/page.tsx
@@ -1,20 +1,25 @@
 import type { Metadata } from "next";
-import { getTermById } from "@/lib/mock/terms";
+import { getTermById } from "@/lib/actions/terms";
+export const dynamic = 'force-dynamic';
 
-export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
-  const t = getTermById(params.id);
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
+  const { id } = await params;
+  const data = await getTermById(id);
   return {
-    title: t ? t.term : "Term",
-    description: t ? `Definition for ${t.term}` : "Glossary term",
-    keywords: t ? [t.term, "glossary", "risk", "definition"] : ["glossary", "risk"],
+    title: data ? data.term.term : "Term",
+    description: data ? `Definition for ${data.term.term}` : "Glossary term",
+    keywords: data ? [data.term.term, "glossary", "risk", "definition"] : ["glossary", "risk"],
   };
 }
 
-export default function Page({ params }: { params: { id: string } }) {
-  const term = getTermById(params.id);
-  if (!term) {
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const data = await getTermById(id);
+  if (!data) {
     return <div className="prose max-w-none"><h1>Term not found</h1></div>;
   }
+  const term = data.term;
   return (
     <article className="prose max-w-none">
       <h1 className="text-3xl font-semibold">{term.term}</h1>

--- a/src/app/(root)/terms/edit/[id]/page.tsx
+++ b/src/app/(root)/terms/edit/[id]/page.tsx
@@ -1,29 +1,28 @@
-"use client";
-
 import { TermForm } from "@/components/Term-Form";
-import { getTermById, upsertTerm } from "@/lib/mock/terms";
-import { useRouter } from "next/navigation";
-import { useMemo } from "react";
+import { getTermById, editTerm } from "@/lib/actions/terms";
+import { redirect } from "next/navigation";
 
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const data = await getTermById(id);
 
-export default function Page({ params }: { params: { id: string } }) {
-  const router = useRouter();
-  const term = useMemo(() => getTermById(params.id), [params.id]);
+  const defaultValues = data
+    ? { term: data.term.term, definition: data.term.definition, categoryId: data.term.categoryId }
+    : { term: "", definition: "", categoryId: "" };
+
+  async function onSubmit(values: { term?: string; definition?: string; categoryId?: string }) {
+    "use server";
+    await editTerm(id, values);
+    redirect(`/terms/${id}`);
+  }
 
   return (
-      <TermForm
-          mode="edit"
-          defaultValues={
-            term
-                ? { term: term.term, definition: term.definition, categoryId: term.categoryId }
-                : {}
-          }
-          onSubmit={(values) => {
-            upsertTerm({ id: params.id, ...values });
-            router.push(`/terms/${params.id}`);
-          }}
-          title="Edit Term"
-          submitLabel="Save"
-      />
+    <TermForm
+      mode="edit"
+      defaultValues={defaultValues}
+      onSubmit={onSubmit}
+      title="Edit Term"
+      submitLabel="Save"
+    />
   );
 }

--- a/src/lib/actions/categories.ts
+++ b/src/lib/actions/categories.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { db } from "@/lib/db";
+import { categories, insertCategorySchema, type Category } from "@/lib/db/schema";
+import { desc, eq } from "drizzle-orm";
+import { z } from "zod";
+
+export async function getCategories(): Promise<Category[]> {
+  return db.select().from(categories).orderBy(desc(categories.createdAt));
+}
+
+export async function getTCategoryById(categoryId: string): Promise<Category | null> {
+  const id = z.string().uuid().parse(categoryId);
+  const [c] = await db.select().from(categories).where(eq(categories.id, id));
+  return c ?? null;
+}
+
+export async function createCategory(input: unknown): Promise<{ id: string }> {
+  const parsed = insertCategorySchema.parse(input);
+  const toInsert = { ...parsed, id: parsed.id ?? crypto.randomUUID(), createdAt: parsed.createdAt ?? new Date() };
+  const [inserted] = await db.insert(categories).values(toInsert).returning({ id: categories.id });
+  return { id: inserted.id };
+}
+
+export async function deleteCategory(categoryId: string): Promise<{ id: string }> {
+  const id = z.string().uuid().parse(categoryId);
+  const [deleted] = await db.delete(categories).where(eq(categories.id, id)).returning({ id: categories.id });
+  return { id: deleted.id };
+}

--- a/src/lib/actions/terms.ts
+++ b/src/lib/actions/terms.ts
@@ -1,0 +1,97 @@
+"use server";
+
+import { db } from "@/lib/db";
+import { terms, insertTermSchema, type Term } from "@/lib/db/schema";
+import { and, desc, eq, ilike, ne } from "drizzle-orm";
+import { z } from "zod";
+
+export type TermDetails = {
+  term: Term & { category?: { id: string; name: string } };
+  relatedTerms: Term[];
+  crossReferences: Term[];
+};
+
+export async function getTerms(): Promise<Term[]> {
+  const rows = await db.select().from(terms).orderBy(desc(terms.createdAt));
+  return rows;
+}
+
+export async function getTermById(termId: string): Promise<TermDetails | null> {
+  const id = z.string().uuid().parse(termId);
+
+  const t = await db.query.terms.findFirst({
+    where: eq(terms.id, id),
+    with: {
+      category: true,
+    },
+  });
+
+  if (!t) return null;
+
+  const relatedTerms = await db
+    .select()
+    .from(terms)
+    .where(and(eq(terms.categoryId, t.categoryId), ne(terms.id, t.id)));
+
+  const crossReferences = await db
+    .select()
+    .from(terms)
+    .where(ilike(terms.definition, `%${t.term}%`));
+
+  const crossRefsFiltered = crossReferences.filter((r) => r.id !== t.id);
+
+  const categoryData = t.category
+    ? { id: t.category.id, name: t.category.name }
+    : undefined;
+
+  const base: Term = {
+    id: t.id,
+    term: t.term,
+    definition: t.definition,
+    categoryId: t.categoryId,
+    createdAt: t.createdAt,
+    updatedAt: t.updatedAt,
+  };
+
+  return {
+    term: { ...base, category: categoryData },
+    relatedTerms,
+    crossReferences: crossRefsFiltered,
+  };
+}
+
+export async function createTerm(input: unknown): Promise<{ id: string }> {
+  const parsed = insertTermSchema.parse(input);
+  const toInsert = {
+    ...parsed,
+    id: parsed.id ?? crypto.randomUUID(),
+    createdAt: parsed.createdAt ?? new Date(),
+    updatedAt: parsed.updatedAt ?? new Date(),
+  };
+
+  const [inserted] = await db.insert(terms).values(toInsert).returning({ id: terms.id });
+  return { id: inserted.id };
+}
+
+export async function editTerm(termId: string, input: unknown): Promise<{ id: string }> {
+  const id = z.string().uuid().parse(termId);
+  const updateSchema = insertTermSchema
+    .pick({ term: true, definition: true, categoryId: true })
+    .partial()
+    .refine((obj) => Object.keys(obj).length > 0, "At least one field must be provided");
+  const data = updateSchema.parse(input);
+
+  const [updated] = await db
+    .update(terms)
+    .set({ ...data, updatedAt: new Date() })
+    .where(eq(terms.id, id))
+    .returning({ id: terms.id });
+
+  return { id: updated.id };
+}
+
+export async function deleteTerm(termId: string): Promise<{ id: string }> {
+  const id = z.string().uuid().parse(termId);
+  const [deleted] = await db.delete(terms).where(eq(terms.id, id)).returning({ id: terms.id });
+  return { id: deleted.id };
+}


### PR DESCRIPTION
# feat(glossary): Server Actions CRUD for Terms & Categories + page wiring + params fix

## Summary
Implements comprehensive Next.js Server Actions system for glossary terms management, replacing mock data with full database integration using Drizzle ORM + Neon PostgreSQL.

**Key Changes:**
- **New server actions**: `src/lib/actions/terms.ts` and `src/lib/actions/categories.ts` with full CRUD operations and Zod validation
- **Database integration**: All pages now fetch from PostgreSQL instead of hardcoded mock data
- **Enhanced term details**: `getTermById` returns related terms (same category) and cross-references (terms mentioned in definitions)
- **Next.js v15 fix**: Fixed async `params` handling in dynamic routes (`/terms/[id]` and `/terms/edit/[id]`)
- **Dynamic rendering**: Added `force-dynamic` exports to prevent build-time database queries

## Review & Testing Checklist for Human
- [ ] **Database connectivity**: Verify all CRUD operations work against the Neon database (create, read, update, delete terms)
- [ ] **Form flows**: Test both create-term and edit-term forms submit correctly and redirect to term detail pages
- [ ] **Term detail pages**: Verify `/terms/[id]` loads properly with related terms and cross-references displayed
- [ ] **Cross-reference logic**: Check that the `ilike` pattern matching for cross-references produces sensible results and doesn't cause performance issues
- [ ] **Navigation**: Test full user journey from home → create term → view term → edit term without runtime errors

### Notes
⚠️ **Database integration was not fully tested locally** due to network connectivity issues during the build process. The code compiles successfully but requires manual verification against the live Neon database.

The cross-reference detection uses naive string matching (`ilike(terms.definition, %${term}%)`) which may need refinement based on actual usage patterns.

**Link to Devin run**: https://app.devin.ai/sessions/ab6d602f57c04f24a7ad4ac2865fb135  
**Requested by**: Archer Zou (@archerzou)