### PR TITLE
Fix TS71007: Rename onSubmit to onSubmitAction in client components (AuthForm, TermForm)

### DIFF
--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -2,5 +2,5 @@ import AuthForm from "@/components/AuthForm";
 import { signIn } from "@/lib/auth/actions";
 
 export default function Page() {
-  return <AuthForm mode="sign-in" onSubmit={signIn} />;
+  return <AuthForm mode="sign-in" onSubmitAction={signIn} />;
 }

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -2,5 +2,5 @@ import AuthForm from "@/components/AuthForm";
 import {signUp} from "@/lib/auth/actions";
 
 export default function SignUpPage() {
-  return <AuthForm mode="sign-up" onSubmit={signUp} />;
+  return <AuthForm mode="sign-up" onSubmitAction={signUp} />;
 }

--- a/src/app/(root)/create-term/page.tsx
+++ b/src/app/(root)/create-term/page.tsx
@@ -17,7 +17,7 @@ export default async function Page() {
   return (
     <TermForm
       mode="create"
-      onSubmit={onSubmit}
+      onSubmitAction={onSubmit}
       title="Create a Term"
       submitLabel="Submit"
       categories={categories.map(c => ({ id: c.id, name: c.name }))}

--- a/src/app/(root)/terms/edit/[id]/page.tsx
+++ b/src/app/(root)/terms/edit/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
     <TermForm
       mode="edit"
       defaultValues={defaultValues}
-      onSubmit={onSubmit}
+      onSubmitAction={onSubmit}
       title="Edit Term"
       submitLabel="Save"
       categories={categories.map(c => ({ id: c.id, name: c.name }))}

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -15,11 +15,11 @@ type FormValues = { name?: string; email: string; password: string };
 export default function AuthForm({
   mode = "sign-in",
   className,
-  onSubmit,
+  onSubmitAction,
 }: {
   mode?: Mode;
   className?: string;
-  onSubmit?: (formData: FormData) => Promise<{ ok?: boolean; error?: string } | undefined | null>;
+  onSubmitAction?: (formData: FormData) => Promise<{ ok?: boolean; error?: string } | undefined | null>;
 }) {
   const router = useRouter();
 
@@ -31,14 +31,14 @@ export default function AuthForm({
   const [serverError, setServerError] = React.useState<string | null>(null);
 
   const handle = async (data: FormValues) => {
-    if (!onSubmit) return;
+    if (!onSubmitAction) return;
     setServerError(null);
     const fd = new FormData();
     if (mode === "sign-up" && data.name) fd.append("name", data.name);
     fd.append("email", data.email);
     fd.append("password", data.password);
 
-    const result = await onSubmit(fd);
+    const result = await onSubmitAction(fd);
     if (result?.ok) {
       router.push("/");
     } else if (result && "error" in result && result.error) {

--- a/src/components/Term-Form.tsx
+++ b/src/components/Term-Form.tsx
@@ -24,7 +24,7 @@ export type TermFormValues = z.infer<typeof TermSchema>;
 export function TermForm({
   mode,
   defaultValues,
-  onSubmit,
+  onSubmitAction,
   submitLabel,
   className,
   title,
@@ -32,7 +32,7 @@ export function TermForm({
 }: {
   mode: "create" | "edit";
   defaultValues?: Partial<TermFormValues>;
-  onSubmit: (values: TermFormValues) => Promise<void> | void;
+  onSubmitAction: (values: TermFormValues) => Promise<void> | void;
   submitLabel?: string;
   className?: string;
   title?: string;
@@ -49,7 +49,7 @@ export function TermForm({
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(async (v) => { await onSubmit(v); })} className={cn("space-y-6", className)}>
+      <form onSubmit={form.handleSubmit(async (v) => { await onSubmitAction(v); })} className={cn("space-y-6", className)}>
         <h1 className="text-3xl font-semibold">{title ?? (mode === "create" ? "Create a Term" : "Edit Term")}</h1>
 
         <FormField


### PR DESCRIPTION
# Fix TS71007: Rename onSubmit to onSubmitAction in client components (AuthForm, TermForm)

## Summary
Fixed TypeScript errors TS71007 by renaming the `onSubmit` prop to `onSubmitAction` in two client components (`AuthForm` and `TermForm`) and updating all their usages across the codebase. This satisfies Next.js App Router requirements that non-Server Action functions in "use client" components must have names ending with "Action" or be named "action".

**Files changed:**
- `AuthForm.tsx` - Renamed prop and internal references  
- `Term-Form.tsx` - Renamed prop and internal references
- 4 page files that use these components - Updated prop names in JSX

## Review & Testing Checklist for Human
This PR touches critical user authentication and content management flows, so thorough testing is recommended:

- [ ] **Test authentication flows**: Verify sign-in and sign-up forms work correctly and redirect properly after submission
- [ ] **Test term management**: Verify creating new terms and editing existing terms work without errors  
- [ ] **Check browser console**: Ensure no prop-related runtime errors appear when using these forms
- [ ] **Verify TS errors resolved**: Confirm `npm run lint` or `tsc --noEmit` no longer shows TS71007 errors for these components

### Notes
- Only prop names were changed; no functional logic was modified
- All Server Actions (`signIn`, `signUp`, `onSubmit` functions in pages) remain unchanged and are still properly passed to components
- Link to Devin run: https://app.devin.ai/sessions/3e102492e59645b1921b38a7d819347b
- Requested by: Archer Zou (@archerzou)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized form submission handling across the sign-in, sign-up, create term, and edit term pages for consistency.
  - Unified form components to use a consistent submission action, improving maintainability and reducing potential confusion.
  - No changes to user-facing behavior: existing flows, validations, and navigation remain the same.
  - No impact on performance or functionality; this is an internal consistency update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->