### PR TITLE
Add loading skeleton UI for Home page

### DIFF
--- a/src/app/(root)/loading.tsx
+++ b/src/app/(root)/loading.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <Skeleton className="h-12 w-full" />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {Array.from({ length: 12 }).map((_, i) => (
+          <Skeleton key={i} className="h-8 w-10 rounded-md" />
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 9 }).map((_, i) => (
+          <div key={i} className="space-y-3 rounded-2xl p-4">
+            <Skeleton className="h-6 w-2/3" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+            <Skeleton className="h-4 w-4/6" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+function cn(...classes: Array<string | undefined | false | null>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />;
+}


### PR DESCRIPTION
# Add loading skeleton UI for Home page

## Summary
Adds a loading skeleton UI to prevent users from seeing a blank white page while the home page loads. Creates two new files:
- `src/app/(root)/loading.tsx` - Next.js loading file with skeleton placeholders for SearchBar, AlphabetNav, and glossary term grid
- `src/components/ui/skeleton.tsx` - Reusable Skeleton component with animate-pulse styling

## Review & Testing Checklist for Human
- [ ] **Test loading behavior**: Navigate to home page and verify skeleton appears during loading
- [ ] **Visual layout verification**: Confirm skeleton layout closely matches actual page structure (SearchBar → AlphabetNav → term cards grid)
- [ ] **Styling consistency**: Check that skeleton styling and responsive breakpoints align with existing design system
- [ ] **No utility conflicts**: Ensure the simple `cn` function doesn't conflict with existing utils (consider using existing utility if available)

### Notes
- Skeleton component follows basic Shadcn/ui patterns with `animate-pulse` and `bg-muted`
- Layout assumes responsive grid structure - may need adjustment if actual page layout differs
- Not locally tested - recommend verifying skeleton timing and visual appearance

**Link to Devin run**: https://app.devin.ai/sessions/36d214e3b570404c9b88206e2b9b841e  
**Requested by**: @archerzou