### PR TITLE
Add email verification guards for Create Term and Edit/Delete buttons

### DIFF
--- a/src/app/(root)/terms/[id]/page.tsx
+++ b/src/app/(root)/terms/[id]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { getTermById } from "@/lib/actions/terms";
+import { getCurrentUser } from "@/lib/auth/actions";
 import { Button } from "@/components/ui/button";
 import { DeleteDialog } from "@/components/DeleteDialog";
 import { BackButton } from "@/components/BackButton";
@@ -21,6 +22,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
 export default async function Page({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const data = await getTermById(id);
+  const user = await getCurrentUser();
   if (!data) {
     return <div className="prose max-w-none"><h1>Term not found</h1></div>;
   }
@@ -30,15 +32,17 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
     <div className="max-w-5xl mx-auto px-4 sm:px-6 py-8 sm:py-10">
       <header className="flex items-end justify-between">
         <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">{term.term}</h1>
-        <div className="flex items-center gap-3">
-          <Link href={`/terms/edit/${id}`}>
-            <Button variant="outline">
-              <Pencil />
-              Edit
-            </Button>
-          </Link>
-          <DeleteDialog termId={id} />
-        </div>
+        {user?.emailVerified && (
+          <div className="flex items-center gap-3">
+            <Link href={`/terms/edit/${id}`}>
+              <Button variant="outline">
+                <Pencil />
+                Edit
+              </Button>
+            </Link>
+            <DeleteDialog termId={id} />
+          </div>
+        )}
       </header>
 
       <hr className="mt-6 border-border" />

--- a/src/components/User.tsx
+++ b/src/components/User.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { FiUser } from "react-icons/fi";
 
-type User = { id: string; name?: string | null; email?: string | null } | null;
+type User = { id: string; name?: string | null; email?: string | null; emailVerified?: boolean | null } | null;
 
 export default function User({
   user,
@@ -49,12 +49,14 @@ export default function User({
               </Link>
             ) : (
               <>
-                <Link
-                  href="/create-term"
-                  className="inline-flex items-center rounded-md bg-primary px-3 h-9 text-primary-foreground text-sm hover:opacity-90"
-                >
-                  Create Term
-                </Link>
+                {user.emailVerified && (
+                  <Link
+                    href="/create-term"
+                    className="inline-flex items-center rounded-md bg-primary px-3 h-9 text-primary-foreground text-sm hover:opacity-90"
+                  >
+                    Create Term
+                  </Link>
+                )}
                 <details className="relative">
                   <summary className="list-none cursor-pointer inline-flex items-center gap-2 px-3 h-9 rounded-full border bg-secondary text-secondary-foreground">
                     <FiUser className="h-4 w-4" />


### PR DESCRIPTION
## Changes

This PR adds authentication guards based on email verification status to protect content management features from unverified users.

### Modified Files

**src/components/User.tsx**
- Updated `User` type to include `emailVerified` property
- Added conditional rendering for "Create Term" button - only shown when `user.emailVerified` is true
- Unverified users will only see their account dropdown without the Create Term button

**src/app/(root)/terms/[id]/page.tsx**
- Added `getCurrentUser` import from auth actions
- Fetch current user data in the page component
- Added conditional rendering for Edit and Delete buttons - only shown when `user?.emailVerified` is true
- Unverified users can still view term details but cannot edit or delete them

### Behavior

- **Guest users (not logged in)**: Can only browse and search terms, no access to create/edit/delete
- **Logged in but unverified users**: Can browse and search terms, no access to create/edit/delete
- **Verified users** (`emailVerified: true`): Full access to create, edit, and delete terms

### Testing

Tested locally with both unverified and logged-out users:
- ✅ Create Term button hidden for unverified users
- ✅ Edit and Delete buttons hidden on term detail pages for unverified users
- ✅ Users can still browse and search terms without restrictions
- ✅ Lint checks pass

---

Link to Devin run: https://app.devin.ai/sessions/61f2341dc8cd43fca59b08594296c906

Requested by: Archer Zou (archer.zou84@gmail.com) | GitHub: @archerzou